### PR TITLE
Improve the BuildList routine, add additional example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,15 @@
-PEG/bin/
-PEG.Tests/obj/
+[Bb]in/
+[Oo]bj/
 *.suo
-PEG/obj/
-PEG.Tests/bin/
-PEG.Samples/obj/
-PEG.Samples/bin/
 *.DS_Store
-packages/
+**/[Pp]ackages/*
 .vs/
+.idea/
+_ReSharper*/
+*.[Rr]e[Ss]harper
+*.DotSettings.user
+
+# NuGet Packages
+*.nupkg
+# NuGet Symbol Packages
+*.snupkg

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,27 @@
+<Project>
+
+    <PropertyGroup>
+        <LangVersion>7.3</LangVersion>
+        <Version>2.0.0</Version>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+        <Authors>Kirk Woll</Authors>
+        <Company />
+        <Product />
+        <Copyright>Copyright 2012-2019</Copyright>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <PackageProjectUrl>https://github.com/kswoll/npeg</PackageProjectUrl>
+        <PackageTags>peg parser</PackageTags>
+        <Description>Parsing expression grammar (PEG) DSL for .NET</Description>
+        <RepositoryUrl>https://github.com/kswoll/npeg</RepositoryUrl>
+		
+        <!-- SourceLink -->
+        <PublishRepositoryUrl>true</PublishRepositoryUrl>
+        <IncludeSymbols>true</IncludeSymbols>
+        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19554-01" PrivateAssets="All"/>
+    </ItemGroup>
+
+</Project>

--- a/PEG.Tests/CppMacro/Macro.cs
+++ b/PEG.Tests/CppMacro/Macro.cs
@@ -1,0 +1,93 @@
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using PEG.Builder;
+
+namespace PEG.Tests.CppMacro
+{
+    [SuppressMessage("ReSharper", "ClassNeverInstantiated.Global")]
+    [SuppressMessage("ReSharper", "UnusedAutoPropertyAccessor.Global")]
+    [SuppressMessage("ReSharper", "CollectionNeverUpdated.Global")]
+    [SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
+    public class Macro
+    {
+        private const string NullString = "<null>";
+        private static readonly PegParser<Macro> parser = new PegParser<Macro>(MacroGrammar.Create());
+        public OrModel Or { get; set; }
+
+        public static Macro Parse(string macro)
+        {
+            return parser.Parse(macro);
+        }
+
+        public override string ToString()
+        {
+            return Or?.ToString() ?? NullString;
+        }
+
+        public class AndModel
+        {
+            [Consume] public List<PrimitiveConditionModel> PrimitiveCondition { get; set; }
+
+            public override string ToString()
+            {
+                var value = string.Join(" && ", PrimitiveCondition);
+                return PrimitiveCondition.Count > 1 ? $"({value})" : value;
+            }
+        }
+
+        public class OrModel
+        {
+            [Consume] public List<AndModel> And { get; set; }
+
+            public override string ToString()
+            {
+                var value = string.Join(" || ", And);
+                return And.Count > 1 ? $"({value})" : value;
+            }
+        }
+
+        public class PrimitiveConditionModel
+        {
+            public OrModel Or { get; set; }
+            public NegateConditionModel NegateCondition { get; set; }
+            public DefinedModel Defined { get; set; }
+            public string Identifier { get; set; }
+
+            public override string ToString()
+            {
+                return Identifier ?? Defined?.ToString() ?? NegateCondition?.ToString() ?? Or?.ToString() ?? NullString;
+            }
+        }
+
+        public class DefinedModel
+        {
+            public IdentifierWrapModel IdentifierWrap { get; set; }
+
+            public override string ToString()
+            {
+                return $"defined({IdentifierWrap})";
+            }
+        }
+
+        public class NegateConditionModel
+        {
+            public OrModel Or { get; set; }
+
+            public override string ToString()
+            {
+                return $"!({Or})";
+            }
+        }
+
+        public class IdentifierWrapModel
+        {
+            public IdentifierWrapModel IdentifierWrap { get; set; }
+            public string Identifier { get; set; }
+
+            public override string ToString()
+            {
+                return Identifier ?? IdentifierWrap?.ToString() ?? NullString;
+            }
+        }
+    }
+}

--- a/PEG.Tests/CppMacro/MacroGrammar.cs
+++ b/PEG.Tests/CppMacro/MacroGrammar.cs
@@ -1,0 +1,72 @@
+using System.Diagnostics.CodeAnalysis;
+using PEG.SyntaxTree;
+
+namespace PEG.Tests.CppMacro
+{
+    [SuppressMessage("ReSharper", "FunctionRecursiveOnAllPaths")]
+    public class MacroGrammar : Grammar<MacroGrammar>
+    {
+        /// <summary>
+        /// You should always make the constructor private so that you never accidentally instantiate it directly.  
+        /// Always use the .Create() method inherited from Grammar.  i.e.  MacroGrammar.Create();
+        /// </summary>
+        private MacroGrammar()
+        {
+        }
+
+        public virtual Expression Root()
+        {
+            return Or();
+        }
+
+        public virtual Expression And()
+        {
+            return PrimitiveCondition() + -("&&" + PrimitiveCondition());
+        }
+
+        public virtual Expression Or()
+        {
+            return And() + -("||" + And());
+        }
+
+        public virtual Expression PrimitiveCondition()
+        {
+            return ~Space() + (('(' + Or() + ')') | Defined() | NegateCondition() | Identifier()) + ~Space();
+        }
+
+        public virtual Expression NegateCondition()
+        {
+            return '!' + Or();
+        }
+
+        public virtual Expression Defined()
+        {
+            return ~Space() + "defined" + IdentifierWrap();
+        }
+
+        public virtual Expression IdentifierWrap()
+        {
+            return ~Space() + (('(' + IdentifierWrap() + ')') | Identifier()) + ~Space();
+        }
+
+        public virtual Expression Identifier()
+        {
+            return IdentifierStartChar() + -IdentifierChar();
+        }
+
+        public virtual Expression IdentifierChar()
+        {
+            return IdentifierStartChar() | '0'.To('9');
+        }
+
+        public virtual Expression IdentifierStartChar()
+        {
+            return 'a'.To('Z') | '_';
+        }
+
+        public virtual Expression Space()
+        {
+            return +(' '._() | '\r' | '\n' | '\t');
+        }
+    }
+}

--- a/PEG.Tests/CppMacro/MacroGrammarTest.cs
+++ b/PEG.Tests/CppMacro/MacroGrammarTest.cs
@@ -1,0 +1,55 @@
+using NUnit.Framework;
+
+namespace PEG.Tests.CppMacro
+{
+    [TestFixture]
+    public class MacroGrammarTest
+    {
+        [Test]
+        public void AndBuiltInIdentifier()
+        {
+            var macro = Macro.Parse("ASMJIT_CXX_CLANG && defined(__has_builtin)");
+            Assert.AreEqual("(ASMJIT_CXX_CLANG && defined(__has_builtin))", macro.ToString());
+        }
+
+        [Test]
+        public void AndNot()
+        {
+            var macro = Macro.Parse("defined(ASMJIT_NO_TEXT) && !defined(ASMJIT_NO_LOGGING)");
+            Assert.AreEqual("(defined(ASMJIT_NO_TEXT) && !(defined(ASMJIT_NO_LOGGING)))", macro.ToString());
+        }
+
+        [Test]
+        public void AndNotOr()
+        {
+            var macro = Macro.Parse(
+                "(defined(_M_IX86) || defined(_M_AMD64) || defined(_M_ARM)) && !defined(MIDL_PASS)"
+            );
+            Assert.AreEqual(
+                "((defined(_M_IX86) || defined(_M_AMD64) || defined(_M_ARM)) && !(defined(MIDL_PASS)))",
+                macro.ToString()
+            );
+        }
+
+        [Test]
+        public void BuiltInIdentifier()
+        {
+            var macro = Macro.Parse("__cplusplus");
+            Assert.AreEqual("__cplusplus", macro.ToString());
+        }
+
+        [Test]
+        public void Defined()
+        {
+            var macro = Macro.Parse("defined(_WIN32)");
+            Assert.AreEqual("defined(_WIN32)", macro.ToString());
+        }
+
+        [Test]
+        public void DefinedSpace()
+        {
+            var macro = Macro.Parse("defined (_WIN64)");
+            Assert.AreEqual("defined(_WIN64)", macro.ToString());
+        }
+    }
+}

--- a/PEG.Tests/PEG.Tests.csproj
+++ b/PEG.Tests/PEG.Tests.csproj
@@ -1,13 +1,15 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.14.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/PEG.Tests/packages.config
+++ b/PEG.Tests/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="NUnit" version="2.6.3" targetFramework="net40" />
-</packages>

--- a/PEG/PEG.csproj
+++ b/PEG/PEG.csproj
@@ -1,21 +1,14 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.1;netstandard2.0;net461</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>2.0.0</Version>
-    <Authors>Kirk Woll</Authors>
-    <Company />
-    <Product />
     <PackageId>PEG</PackageId>
-    <Copyright>Copyright 2012-2019</Copyright>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageProjectUrl>https://github.com/kswoll/npeg</PackageProjectUrl>
-    <PackageTags>peg parser</PackageTags>
+    <IsPackable>true</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
+    <PackageReference Include="System.Reflection.Emit" Version="4.6.0" />
   </ItemGroup>
 
 </Project>

--- a/PEG/packages.config
+++ b/PEG/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="NugetUtilities" version="1.0.16" targetFramework="net45" />
-</packages>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,29 @@
+version: 2.0.{build}
+skip_tags: true
+image: Visual Studio 2019 Preview
+configuration: Release
+pull_requests:
+  do_not_increment_build_number: true
+skip_branch_with_pr: true
+
+environment:
+  LOGGER: '/l:"C:\Program Files\AppVeyor\BuildAgent\dotnetcore\Appveyor.MSBuildLogger.dll"'
+
+build_script:
+  - cmd: dotnet --version
+  - cmd: dotnet build %LOGGER% -v m -c Release
+
+test_script:
+  - cmd: dotnet test -v m -c Release --test-adapter-path:. --logger:Appveyor
+
+
+artifacts:
+  - path: '**\*.nupkg'
+    name: nupkg
+  - path: '**\*.snupkg'
+    name: snupkg
+
+
+cache:
+  - '%LocalAppData%\NuGet\Cache'
+  - '%USERPROFILE%\.nuget\packages'


### PR DESCRIPTION
- Refactor `BuildList` into 2 separate functions to improve code quality.
- Add the first `[Consume]` usage example: C/C++ preprocessor macro grammar.
- Fix AppVeyor CI and improve project infrastructure.

I was wrong about bug in `BuildList`, but I improved code structure nevertheless.